### PR TITLE
Fix how nested data is updated on customers

### DIFF
--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -378,6 +378,66 @@ shared_examples 'Customer API' do
     expect(original.default_source).to_not eq(card.id)
   end
 
+  it 'still has metadata after save when metadata unchanged', live: true do
+    customer = Stripe::Customer.create(source: gen_card_tk, metadata: { order_id: '1234' })
+
+    expect(customer.metadata[:order_id]).to eq('1234')
+    customer.save
+    expect(customer.metadata[:order_id]).to eq('1234')
+  end
+
+  it 'deletes metadata when set to an empty hash', live: true do
+    customer = Stripe::Customer.create(source: gen_card_tk, metadata: { order_id: '1234' })
+
+    expect(customer.metadata[:order_id]).to eq('1234')
+    customer.metadata = {}
+    customer.save
+    expect(customer.metadata[:order_id]).to eq(nil)
+  end
+
+  it 'still has shipping address after save when shipping address unchanged', live: true do
+    customer = Stripe::Customer.create(
+      source: gen_card_tk,
+      shipping: {
+        name: 'John Doe',
+        address: {
+          line1: '2284 Indiana Avenue',
+          city: 'Honolulu',
+          country: 'US',
+          line2: '#404',
+          postal_code: '96813',
+          state: 'HI'
+        }
+      }
+    )
+
+    expect(customer.shipping.address.country).to eq('US')
+    customer.save
+    expect(customer.shipping.address.country).to eq('US')
+  end
+
+  it 'deletes shipping address when set to nil', live: true do
+    customer = Stripe::Customer.create(
+      source: gen_card_tk,
+      shipping: {
+        name: 'John Doe',
+        address: {
+          line1: '2284 Indiana Avenue',
+          city: 'Honolulu',
+          country: 'US',
+          line2: '#404',
+          postal_code: '96813',
+          state: 'HI'
+        }
+      }
+    )
+
+    expect(customer.shipping.address.country).to eq('US')
+    customer.shipping = nil
+    customer.save
+    expect(customer.shipping).to eq(nil)
+  end
+
   it "still has sources after save when sources unchanged" do
     original = Stripe::Customer.create(source: gen_card_tk)
     card = original.sources.data.first


### PR DESCRIPTION
Stripe interprets empty strings as "delete this value". This has several implications for how parameters are treated.

Simply merging the new params with the old customer-object overwrites any current customer attribute containing a hash, as all nested customer attributes are included in the params, regardless of if changes have been made.

This issue has been partially addressed in previous commits, but it does not account for all nested attributes, such as `metadata` and `shipping`. This code has been refactored to work with any nested attribute.

Additionally, passing an empty string as a parameter now sets the value to `nil`, which is closer to how the Stripe API works.